### PR TITLE
removing maven-source-plugin execution during verify phase.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,12 +229,6 @@
           <artifactId>maven-source-plugin</artifactId>
           <version>2.1.2</version>
           <executions>
-            <execution>
-              <phase>verify</phase>
-              <goals>
-                <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
             <!-- http://blog.peterlynch.ca/2010/05/maven-how-to-prevent-generate-sources.html -->
             <!-- here we override the super-pom attach-sources executionid
               which calls sources:jar goal. That goals forks the lifecycle, causing the


### PR DESCRIPTION
This caused Maven releases to deploy source artifacts twice which will be rejected by Nexus if redeploy is disabled and fail the build.
