### PR TITLE
updated jaxws plugin version to support ws-security policies and java…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .repository
 contract/src/main/resources/com/sybase365/mobiliser/framework/
 contract/src/main/resources/com/sybase365/mobiliser/money/
+.project
+.classpath
+.settings
 target

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -32,7 +32,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxws-maven-plugin</artifactId>
-        <version>1.12</version>
+        <version>2.4.1</version>
         <executions>
           <execution>
             <id>weather</id>
@@ -40,6 +40,10 @@
               <goal>wsimport</goal>
             </goals>
             <configuration>
+              <!--  javax.xml.accessExternalSchema argument needed for Java8 -->
+			  <vmArgs>
+				<vmArg>-Djavax.xml.accessExternalSchema=all</vmArg>
+		  	  </vmArgs>
               <wsdlDirectory>src/main/resources</wsdlDirectory>
               <wsdlFiles>
                 <wsdlFile>Weather.wsdl</wsdlFile>
@@ -49,6 +53,7 @@
               <xnocompile>true</xnocompile>
               <staleFile>${project.build.directory}/jaxws/stale/.staleFlag_WeatherService</staleFile>
               <wsdlLocation>/Weather.wsdl</wsdlLocation>
+              <sourceDestDir>${project.build.directory}/jaxws/wsimport/java/</sourceDestDir>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Updated jaxws plugiin to 2.4.1 - previous version was throwing an error to generate stubs from WSDL using WS-Security policies
Added vm-arg to comply with Java 8 jaxp 1.5
