### PR TITLE
Remove unused h2 database dependency.

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -377,15 +377,6 @@
       <version>${version.springbase}</version>
     </dependency>
 
-    <!-- H2 Database for Operations Dashboad data storage -->
-
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>1.3.169</version>
-      <scope>compile</scope>
-    </dependency>
-
     <!-- EHCACHE DEPENDENCIES -->
     <dependency>
       <groupId>org.ehcache</groupId>


### PR DESCRIPTION
This has not been used since 2012 and is no longer referenced in the application context.